### PR TITLE
Change name and URL in library metadata

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,8 +1,7 @@
-name=Sensirion Core Arduino Library
+name=Sensirion Core
 version=0.0.1
 author=Sensirion
 maintainer=Sensirion
 sentence=Library containing code base for Sensirion Sensor Libraries.
 paragraph=All Libraries for Sensirion Sensors use this library as a code base. In this library the Sensirion specific parts for I2C and UART communication are implemented. It provides dynamic frame construction, checksum calculation and buffer handling.
-url=https://developer.sensirion.com
-
+url=https://github.com/Sensirion/Sensirion_Core_Arduino_Library/


### PR DESCRIPTION
It's a bit tautological to include Arduino Library in the name of an Arduino
library. Also the repo URL is more meaningful than the Sensirion developer
page.
