### PR TITLE
Suppressing warnings

### DIFF
--- a/src/SensirionRxFrame.cpp
+++ b/src/SensirionRxFrame.cpp
@@ -53,7 +53,7 @@ uint16_t SensirionRxFrame::getUInt32(uint32_t& data) {
 }
 
 uint16_t SensirionRxFrame::getInt32(int32_t& data) {
-    uint32_t ret;
+    uint32_t ret = 0;
     uint16_t error = getUInt32(ret);
     data = static_cast<int32_t>(ret);
     return error;
@@ -70,7 +70,7 @@ uint16_t SensirionRxFrame::getUInt16(uint16_t& data) {
 }
 
 uint16_t SensirionRxFrame::getInt16(int16_t& data) {
-    uint16_t ret;
+    uint16_t ret = 0;
     uint16_t error = getUInt16(ret);
     data = static_cast<int16_t>(ret);
     return error;
@@ -107,7 +107,7 @@ uint16_t SensirionRxFrame::getFloat(float& data) {
     union {
         uint32_t uInt32Data;
         float floatData;
-    } convert;
+    } convert = { 0 };
     uint16_t error = getUInt32(convert.uInt32Data);
     data = convert.floatData;
     return error;


### PR DESCRIPTION
* SensirionRxFrame.cpp:58:12: warning: 'ret' may be used uninitialized in this function [-Wmaybe-uninitialized]
* SensirionRxFrame.cpp:75:12: warning: 'ret' may be used uninitialized in this function [-Wmaybe-uninitialized]
* SensirionRxFrame.cpp:112:20: warning: 'convert' may be used uninitialized in this function [-Wmaybe-uninitialized]

https://github.com/Seeed-Studio/Wio_Tracker_1110_Examples/issues/18