### PR TITLE
Fixing begin of the TX-frame and issues with recieving an error frame.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,8 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 
 `Unreleased`_
 -------------
+- update to SensirionShdlcTxFrame::begin so the buffer is always filled from position 0.
+. update to SensirionShdlcCommunication::receiveFrame -  if an error frame is recieved, the data part of the frame should not be read even if the length is not 0.
 
 `0.7.1`_ 2024-04-30
 -------------------

--- a/src/SensirionShdlcCommunication.cpp
+++ b/src/SensirionShdlcCommunication.cpp
@@ -124,15 +124,18 @@ uint16_t SensirionShdlcCommunication::receiveFrame(SensirionShdlcRxFrame& frame,
         return RxFrameError | BufferSizeError;
     }
 
-    size_t i = 0;
-    while (i < dataLength) {
-        error = unstuffByte(current, serial, startTime, timeoutMicros);
-        if (error) {
-            return error;
+    // An error frame does not have any data eventhough the value of "dataLength" is not zero.
+    // Therefore, only read data from the buffer if the frame state is 0, i.e, the frame is not of an error frame.
+    
+    if(frame._state == 0 ){
+        for(size_t i = 0; i < dataLength; i++){ 
+            error = unstuffByte(current, serial, startTime, timeoutMicros);
+            if (error) {
+                return error;
+            }
+            frame._buffer[i] = current;
+            checksum += current;
         }
-        frame._buffer[i] = current;
-        checksum += current;
-        i++;
     }
 
     uint8_t expectedChecksum = ~checksum;

--- a/src/SensirionShdlcTxFrame.cpp
+++ b/src/SensirionShdlcTxFrame.cpp
@@ -38,7 +38,7 @@
 
 uint16_t SensirionShdlcTxFrame::begin(uint8_t command, uint8_t address,
                                       uint8_t dataLength) {
-    _index=0;                          
+    _index=0;                   //sets the index to point towards the start of the buffer.       
     _buffer[_index] = 0x7e;
     uint16_t error = addUInt8(address);
     error |= addUInt8(command);

--- a/src/SensirionShdlcTxFrame.cpp
+++ b/src/SensirionShdlcTxFrame.cpp
@@ -38,7 +38,8 @@
 
 uint16_t SensirionShdlcTxFrame::begin(uint8_t command, uint8_t address,
                                       uint8_t dataLength) {
-    _buffer[_index++] = 0x7e;
+    _index=0;                          
+    _buffer[_index] = 0x7e;
     uint16_t error = addUInt8(address);
     error |= addUInt8(command);
     error |= addUInt8(dataLength);


### PR DESCRIPTION
- update to SensirionShdlcTxFrame::begin so the TX-buffer is always filled from position 0.
. update to SensirionShdlcCommunication::receiveFrame -  if an error frame is recieved, the data part of the frame should not be read even if the length is not 0.
